### PR TITLE
Fix: AccessControlListNotSupported: The bucket does not allow ACLs

### DIFF
--- a/modules/cloudfront-proxy-config/main.tf
+++ b/modules/cloudfront-proxy-config/main.tf
@@ -17,6 +17,14 @@ resource "aws_s3_bucket" "proxy_config_store" {
 resource "aws_s3_bucket_acl" "proxy_config_store" {
   bucket = aws_s3_bucket.proxy_config_store.id
   acl    = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership]
+}
+
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {
+  bucket = aws_s3_bucket.proxy_config_store.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
 }
 
 data "aws_iam_policy_document" "cf_access" {

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -9,7 +9,7 @@ variable "proxy_module_version" {
 
 variable "lambda_default_runtime" {
   type    = string
-  default = "nodejs14.x"
+  default = "nodejs18.x"
 }
 
 variable "lambda_role_permissions_boundary" {

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -17,6 +17,14 @@ resource "aws_s3_bucket" "static_upload" {
 resource "aws_s3_bucket_acl" "static_upload" {
   bucket = aws_s3_bucket.static_upload.id
   acl    = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership_upload]
+}
+
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership_upload" {
+  bucket = aws_s3_bucket.static_upload.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
 }
 
 # We are using versioning here to ensure that no file gets overridden at upload
@@ -50,6 +58,14 @@ resource "aws_s3_bucket" "static_deploy" {
 resource "aws_s3_bucket_acl" "static_deploy" {
   bucket = aws_s3_bucket.static_deploy.id
   acl    = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.s3_bucket_acl_ownership_deploy]
+}
+
+resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership_deploy" {
+  bucket = aws_s3_bucket.static_deploy.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "static_deploy" {
@@ -196,7 +212,7 @@ module "deploy_trigger" {
   function_name             = "${var.deployment_name}_tfn-deploy"
   description               = "Managed by Terraform Next.js"
   handler                   = "handler.handler"
-  runtime                   = "nodejs14.x"
+  runtime                   = "nodejs18.x"
   memory_size               = 1024
   timeout                   = local.lambda_timeout
   publish                   = true

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "lambda_environment_variables" {
 variable "lambda_runtime" {
   description = "Lambda Function runtime"
   type        = string
-  default     = "nodejs16.x"
+  default     = "nodejs18.x"
 }
 
 variable "lambda_memory_size" {


### PR DESCRIPTION
Fix: AccessControlListNotSupported: The bucket does not allow ACLs
chore: sets nodejs18.x as the default runtime